### PR TITLE
テキスト・URLの設定画面を追加

### DIFF
--- a/includes/admin/class-wp-ie-buster-admin.php
+++ b/includes/admin/class-wp-ie-buster-admin.php
@@ -1,0 +1,125 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
+}
+
+class Wp_Ie_Buster_Admin {
+
+  private $plugin_name;
+
+  private $option_name;
+
+  public function __construct( $plugin_name ) {
+    $this->plugin_name = $plugin_name;
+    $this->option_name = $plugin_name;
+
+    add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
+  }
+
+  public function plugins_loaded() {
+    $this->options = get_option( $this->option_name );
+
+    add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+    add_action( 'admin_init', array( $this, 'admin_init' ) );
+  }
+
+  public function admin_menu() {
+    add_options_page(
+      __( 'WP IE Buster', $this->plugin_name ),
+      __( 'WP IE Buster', $this->plugin_name ),
+      'manage_options',
+      $this->plugin_name . '-settings',
+      [ $this, 'display' ]
+    );
+  }
+
+  function admin_init() {
+    register_setting(
+      $this->plugin_name,
+      $this->option_name
+    );
+    add_settings_section(
+      'basic_settings',
+      __( '基本設定', $this->plugin_name ),
+      null,
+      $this->plugin_name
+    );
+    add_settings_field(
+      'main_text',
+      __( 'メインテキスト', $this->plugin_name ),
+      [ $this, 'main_text_callback' ],
+      $this->plugin_name,
+      'basic_settings'
+    );
+    add_settings_field(
+      'link_text',
+      __( 'リンクテキスト', $this->plugin_name ),
+      [ $this, 'link_text_callback' ],
+      $this->plugin_name,
+      'basic_settings'
+    );
+    add_settings_field(
+      'url',
+      __( 'URL', $this->plugin_name ),
+      [ $this, 'url_callback' ],
+      $this->plugin_name,
+      'basic_settings'
+    );
+  }
+
+  public function main_text_callback() {
+    $main_text = isset( $this->options['main_text'] ) ? $this->options['main_text'] : '';
+    ?>
+    <input
+      name="<?php echo $this->option_name; ?>[main_text]"
+      type="text"
+      id="main_text"
+      placeholder="<?php esc_attr_e( Wp_Ie_Buster::get_default_main_text() ); ?>"
+      value="<?php esc_attr_e( $main_text ); ?>"
+      class="regular-text"
+    >
+    <?php
+  }
+
+  public function link_text_callback() {
+    $link_text = isset( $this->options['link_text'] ) ? $this->options['link_text'] : '';
+    ?>
+    <input
+      name="<?php echo $this->option_name; ?>[link_text]"
+      type="text"
+      id="link_text"
+      placeholder="<?php esc_attr_e( Wp_Ie_Buster::get_default_link_text() ); ?>"
+      value="<?php esc_attr_e( $link_text ); ?>"
+      class="regular-text"
+    >
+    <?php
+  }
+
+  public function url_callback() {
+    $url = isset( $this->options['url'] ) ? $this->options['url'] : '';
+    ?>
+    <input
+      name="<?php echo $this->option_name; ?>[url]"
+      type="text"
+      id="url"
+      placeholder="<?php esc_attr_e( Wp_Ie_Buster::get_default_url() ); ?>"
+      value="<?php esc_attr_e( $url ); ?>"
+      class="regular-text"
+    >
+    <?php
+  }
+
+  function display() {
+    ?>
+    <form action='options.php' method='post'>
+      <h1><?php _e( 'WP IE Buster', $this->plugin_name ); ?></h1>
+      <?php
+      settings_fields( $this->plugin_name );
+      do_settings_sections( $this->plugin_name );
+      submit_button();
+      ?>
+    </form>
+    <?php
+  }
+}

--- a/includes/class-wp-ie-buster.php
+++ b/includes/class-wp-ie-buster.php
@@ -1,0 +1,60 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
+}
+
+class Wp_Ie_Buster {
+
+  private $plugin_name;
+
+  private static $default_main_text;
+  private static $default_link_text;
+  private static $default_url;
+
+  public function __construct() {
+    $this->plugin_name = 'wp-ie-buster';
+
+    self::$default_main_text = __( 'ご利用のインターネットブラウザは推奨環境ではありません。Webサイトの動作が保証できませんので、最新の Google Chrome をご利用ください。', $this->plugin_name );
+    self::$default_link_text = __( 'ダウンロードページへ', $this->plugin_name );
+    self::$default_url       = 'https://www.google.com/chrome/';
+
+    if ( is_admin() ) {
+      $admin = new Wp_Ie_Buster_Admin( $this->plugin_name );
+    }
+
+    add_action( 'wp_footer', array( $this, 'wp_ie_buster_app_print' ) );
+  }
+
+  public function wp_ie_buster_app_print() {
+    global $is_IE;
+    if ( $is_IE ) {
+      $options   = get_option( $this->plugin_name );
+      $main_text = ( ! empty( $options['main_text'] ) ) ? $options['main_text'] : self::$default_main_text;
+      $link_text = ( ! empty( $options['link_text'] ) ) ? $options['link_text'] : self::$default_link_text;
+      $url       = ( ! empty( $options['url'] ) ) ? $options['url'] : self::$default_url;
+      echo '
+    }
+    <div id="ie-buster-app" style="position: fixed; top: 0px; left: 0; width: 100%; padding: 16px; box-sizing: border-box; z-index: 999999;">
+      <div style="position: relative; width: 100%; max-width:866px; margin: 0 auto; padding: 16px 20px; background-color: #fff; box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 5px 0px; box-sizing: border-box; font-family: SegoeUI, Meiryo, sans-serif;">
+        <p style="display: block; float: left; width: 100%; max-width: 664px; margin: 0; color: #000; font-size: 14px; font-weight: 400; line-height: 1.5;">' . esc_html( $main_text ) . '</p>
+        <a style="display: block; float: right; height: 36px; width: 154px; padding: 0 16px; background-color: rgb(0, 120, 212); box-sizing: border-box; color: #fff; font-size: 12px; font-weight: 400; line-height: 36px; text-align: center; text-decoration: none; white-space: nowrap;" href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $link_text ) . '</a>
+        <div style="clear: both;"></div>
+      </div>
+    </div>
+  ';
+    }
+  }
+
+  public static function get_default_main_text() {
+    return self::$default_main_text;
+  }
+
+  public static function get_default_link_text() {
+    return self::$default_link_text;
+  }
+
+  public static function get_default_url() {
+    return self::$default_url;
+  }
+}

--- a/wp-ie-buster-dev.php
+++ b/wp-ie-buster-dev.php
@@ -9,18 +9,15 @@ Author URI: https://qrac.jp
 License: GPLv2 or later
 */
 
-function wp_ie_buster_app_print() {
-  global $is_IE;
-  if ($is_IE) {
-  echo '
-    <div id="ie-buster-app" style="position: fixed; top: 0px; left: 0; width: 100%; padding: 16px; box-sizing: border-box; z-index: 999999;">
-      <div style="position: relative; width: 100%; max-width:866px; margin: 0 auto; padding: 16px 20px; background-color: #fff; box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 5px 0px; box-sizing: border-box; font-family: SegoeUI, Meiryo, sans-serif;">
-        <p style="display: block; float: left; width: 100%; max-width: 664px; margin: 0; color: #000; font-size: 14px; font-weight: 400; line-height: 1.5;">ご利用のインターネットブラウザは推奨環境ではありません。Webサイトの動作が保証できませんので、最新の Google Chrome をご利用ください。</p>
-        <a style="display: block; float: right; height: 36px; width: 154px; padding: 0 16px; background-color: rgb(0, 120, 212); box-sizing: border-box; color: #fff; font-size: 12px; font-weight: 400; line-height: 36px; text-align: center; text-decoration: none; white-space: nowrap;" href="https://www.google.com/chrome/" target="_blank" rel="noopener noreferrer">ダウンロードページへ</a>
-        <div style="clear: both;"></div>
-      </div>
-    </div>
-  ';
-  }
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
 }
-add_action( 'wp_footer', 'wp_ie_buster_app_print' );
+
+require_once( 'includes/class-wp-ie-buster.php' );
+require_once( 'includes/admin/class-wp-ie-buster-admin.php' );
+
+function wp_ie_buster() {
+  new Wp_Ie_Buster();
+}
+
+wp_ie_buster();


### PR DESCRIPTION
参考：https://github.com/qrac/wp-ie-buster-dev/issues/4

管理画面の [設定] > [WP IE Buster] からメインテキスト、リンクテキスト、URL を設定できるようにしてみました。
なお、未設定時はデフォルト値（これまでと同じ）が使われるようになっています。

![wpiebuster-settings](https://user-images.githubusercontent.com/84167/52541930-dc62de00-2ddd-11e9-9f25-8a62b98e328b.jpg)